### PR TITLE
builtin - env의 getter, setter 기능 구현, cd 단독기능 완성(예외보완 필요) #12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 a.out
 *.dSYM
 readline
+*.json

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ilhna <ilhna@student.42seoul.kr>           +#+  +:+       +#+        */
+/*   By: ejachoi <ejachoi@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/20 23:53:34 by ilhna             #+#    #+#             */
-/*   Updated: 2023/01/24 01:55:08 by ilhna            ###   ########.fr       */
+/*   Updated: 2023/01/24 12:54:40 by ejachoi          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,7 +23,7 @@ typedef struct s_env
 
 typedef struct s_config
 {
-	t_list	*env_node;
+	t_list	*env_list;
 }	t_config;
 
 void	load_config(t_config *config, char **envp);

--- a/srcs_mandatory/load_config.c
+++ b/srcs_mandatory/load_config.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   load_config.c                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ilhna <ilhna@student.42seoul.kr>           +#+  +:+       +#+        */
+/*   By: ejachoi <ejachoi@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/24 01:47:41 by ilhna             #+#    #+#             */
-/*   Updated: 2023/01/24 01:50:26 by ilhna            ###   ########.fr       */
+/*   Updated: 2023/01/24 12:56:11 by ejachoi          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,18 +16,18 @@
 void	load_config(t_config *config, char **envp)
 {
 	int		env_idx;
-	t_list	*node;
+	t_list	*cur;
 
 	env_idx = 0;
-	node = ft_lstnew(new_env(envp[env_idx]));
-	if (node == NULL)
+	config->env_list = ft_lstnew(new_env(envp[env_idx]));
+	if (config->env_list == NULL)
 		panic("Fail: ft_lstnew()");
-	config->env_node = node;
+	cur = config->env_list;
 	while (envp[++env_idx])
 	{
-		node->next = ft_lstnew((void *)new_env(envp[env_idx]));
-		if (node->next == NULL)
+		cur->next = ft_lstnew((void *)new_env(envp[env_idx]));
+		if (cur->next == NULL)
 			panic("Fail: ft_lstnew()");
-		node = node->next;
+		cur = cur->next;
 	}
 }

--- a/srcs_mandatory/main.c
+++ b/srcs_mandatory/main.c
@@ -294,7 +294,7 @@ int main(int argc, char **argv, char **envp)
 		{
 			if (builtin_cd(buf, config))
 				printf("cannot cd %s\n", buf+3);
-      		continue;
+      		// continue;
     	}
 		if (fork() == 0)
 			runcmd(parsecmd(buf), config);

--- a/srcs_mandatory/main.c
+++ b/srcs_mandatory/main.c
@@ -77,27 +77,53 @@ char *ft_gets(char *buf, int max)
 }
 
 #include <sys/param.h>
+
+t_list	*get_env_list(t_list *env_list, char *env_key)
+{
+	t_env *cur_env;
+	
+	while (env_list)
+	{
+		cur_env = (t_env *)env_list->content;
+		if (!ft_strncmp(cur_env->key, env_key, ft_strlen(env_key)))
+			return (env_list);
+		env_list = env_list->next;
+	}
+	return NULL;
+}
+
+void	set_env_list(t_list *env_list, char *env_key, char *new_value)
+{
+	t_env *cur_env;
+	
+	while (env_list)
+	{
+		cur_env = (t_env *)env_list->content;
+		if (!ft_strncmp(cur_env->key, env_key, ft_strlen(env_key)))
+		{
+			cur_env->value = new_value;
+			return ;
+		}
+		env_list = env_list->next;
+	}
+}
+
+
 // int builtin_echo(char *const argv[])
 // {
 // }
 
-// int builtin_cd(char *const argv[], t_config config)
-// {
-// 	if (argv[1] == NULL)
-// 	// go to $HOME dir
-// 		goto_home_dir();
-// 	else
-// 	{
-// 			if (argv[1][0] == '-' || argv[1][0] == '~')
-
-
-// 			if (chdir(argv[1] == 0))
-// 			{
-				
-// 			}
-// 	}
-
-// }
+int builtin_cd(char *const buf, t_config config)
+{
+	buf[strlen(buf)-1] = 0;
+    if (chdir(buf+3))
+	{
+		printf("error check\n");
+		return (1);
+	}
+	set_env_list(config.env_list, "PWD", buf);
+	return (0);
+}
 
 int	builtin_pwd(void)
 {
@@ -138,9 +164,9 @@ void runcmd(struct cmd *cmd, t_config config)
 
 		// if (ft_strnstr(ecmd->argv[0], "echo", 5))
 		// 	builtin_echo(ecmd->argv);
-		// else if (ft_strnstr(ecmd->argv[0], "cd", 3))
-		// 	builtin_cd(ecmd->argv, config);
-		if (ft_strnstr(ecmd->argv[0], "pwd", 4))
+		if (ft_strnstr(ecmd->argv[0], "cd", 3))
+			result = 0;
+		else if (ft_strnstr(ecmd->argv[0], "pwd", 4))
 			result = builtin_pwd();
 		// else if (ft_strnstr(ecmd->argv[0], "export", 7))
 		// 	builtin_export(ecmd->argv);
@@ -264,6 +290,12 @@ int main(int argc, char **argv, char **envp)
 
 	while (getcmd(buf, sizeof(buf)) >= 0)
 	{
+		if(buf[0] == 'c' && buf[1] == 'd' && buf[2] == ' ')
+		{
+			if (builtin_cd(buf, config))
+				printf("cannot cd %s\n", buf+3);
+      		continue;
+    	}
 		if (fork() == 0)
 			runcmd(parsecmd(buf), config);
 		wait(&status);


### PR DESCRIPTION
[1edb80b](https://github.com/ejaee/42Minishell/pull/23/commits/1edb80b8a6f83d362f73df1ca641342836f8826c)

현재 코드의 문제점 및 개선 방향입니다

[문제점] cd .. | pwd 의 경우
pwd 만 실행되어야하지만
cd 이하를 모두 파일 명으로 인식해 오류로 인식합니다

-> cd 이하를 확인하고 공백이 발견되는 시점까지 포인터를 밀어서 파싱부에 전달하겠습니다

[추가] pwd | cd .. 의 경우
를 위해서 runcmd 내부에도 cd의 경우의 수를 만들었습니다
init 값 -1인 result  를 cd 일 경우 0을 부여하여 자연스럽게 pass
아무것도 출력이 되면 안되는 것으로 구현했습니다

get env 는 export를 고려해 노드가 반환됩니다


----

[2ec0245](https://github.com/ejaee/42Minishell/pull/23/commits/2ec0245c38ea744d8b0f8988f23af3c57f393854)

생각보다 간단하게 구현되었습니다 파싱이 너무 잘되서 기존에 있던 continue 만 없어도 자식 프로세스에서 cd를 실행만 안시키면 됩니다

해결한 예외사항 -> cd .. | pwd 결과 : pwd