### PR TITLE
Ejaee/issue11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ a.out
 readline
 *.json
 .cache
+-std=*

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: ilhna <ilhna@student.42seoul.kr>           +#+  +:+       +#+         #
+#    By: choiejae <choiejae@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2023/01/20 23:39:37 by ilhna             #+#    #+#              #
-#    Updated: 2023/01/24 13:30:48 by ilhna            ###   ########.fr        #
+#    Updated: 2023/01/26 15:08:41 by choiejae         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -99,6 +99,10 @@ re:
 
 .PHONY: debug
 debug: $(NAME)
+
+run:
+	make
+	./minishell
 
 .PHONY: ccm
 ccm:

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ilhna <ilhna@student.42seoul.kr>           +#+  +:+       +#+        */
+/*   By: choiejae <choiejae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/20 23:53:34 by ilhna             #+#    #+#             */
-/*   Updated: 2023/01/25 15:15:58 by ilhna            ###   ########.fr       */
+/*   Updated: 2023/01/26 13:44:11 by choiejae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,13 @@
 
 # include "libft.h"
 
+// color.h
+# define RED	"\x1b[31m"
+# define GREEN	"\x1b[32m"
+# define YELLOW	"\x1b[33m"
+# define BLUE	"\x1b[34m"
+# define RESET	"\x1b[0m"
+
 typedef struct s_env
 {
 	char	*key;
@@ -25,7 +32,8 @@ typedef struct s_env
 
 typedef struct s_config
 {
-	t_list	*env_list;
+	t_list	*head;
+	t_list	*tail;
 }	t_config;
 
 void	load_config(t_config *config, char **envp);

--- a/libft/Makefile
+++ b/libft/Makefile
@@ -3,10 +3,10 @@
 #                                                         :::      ::::::::    #
 #    Makefile                                           :+:      :+:    :+:    #
 #                                                     +:+ +:+         +:+      #
-#    By: ilhna <ilhna@student.42seoul.kr>           +#+  +:+       +#+         #
+#    By: choiejae <choiejae@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2022/07/08 21:24:48 by ilhna             #+#    #+#              #
-#    Updated: 2023/01/24 00:19:27 by ilhna            ###   ########.fr        #
+#    Updated: 2023/01/26 15:11:56 by choiejae         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -32,6 +32,7 @@ SOURCES_MANDATORY = \
 			ft_split_one_cstm.c \
 
 SOURCES_BONUS = \
+			ft_d_lstadd_back.c  \
 			ft_lstadd_back.c  \
 			ft_lstadd_front.c \
 			ft_lstclear.c     \

--- a/libft/ft_d_lstadd_back.c
+++ b/libft/ft_d_lstadd_back.c
@@ -1,28 +1,26 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   ft_lstadd_back.c                                   :+:      :+:    :+:   */
+/*   ft_d_lstadd_back.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: choiejae <choiejae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/07/13 16:48:02 by ilhna             #+#    #+#             */
-/*   Updated: 2023/01/26 15:11:26 by choiejae         ###   ########.fr       */
+/*   Updated: 2023/01/26 15:01:56 by choiejae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 
-void	ft_lstadd_back(t_list **lst, t_list *new)
+void	ft_d_lstadd_back(t_list **lst, t_list *new)
 {
 	t_list	**lstcp;
-	t_list	*lastnode;
+	t_list	*dummy_node;
 
 	lstcp = lst;
-	if (*lstcp == (void *)0)
-		*lstcp = new;
-	else
-	{
-		lastnode = ft_lstlast(*lstcp);
-		lastnode->next = new;
-	}
+	dummy_node = ft_lstlast(*lstcp);
+	dummy_node->prev->next = new;
+	new->prev = dummy_node->prev;
+	dummy_node->prev = new;
+	new->next = dummy_node;
 }

--- a/libft/ft_lstadd_back.c
+++ b/libft/ft_lstadd_back.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ft_lstadd_back.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ilhna <ilhna@student.42seoul.kr>           +#+  +:+       +#+        */
+/*   By: choiejae <choiejae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/07/13 16:48:02 by ilhna             #+#    #+#             */
-/*   Updated: 2022/07/20 15:56:18 by ilhna            ###   ########.fr       */
+/*   Updated: 2023/01/26 11:26:23 by choiejae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,14 +15,17 @@
 void	ft_lstadd_back(t_list **lst, t_list *new)
 {
 	t_list	**lstcp;
-	t_list	*lastnode;
+	t_list	*dummy_node;
 
 	lstcp = lst;
 	if (*lstcp == (void *)0)
 		*lstcp = new;
 	else
 	{
-		lastnode = ft_lstlast(*lstcp);
-		lastnode->next = new;
+		dummy_node = ft_lstlast(*lstcp);
+		dummy_node->prev->next = new;
+		new->prev = dummy_node->prev;
+		dummy_node->prev = new;
+		new->next = dummy_node;
 	}
 }

--- a/libft/ft_lstdelone.c
+++ b/libft/ft_lstdelone.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ft_lstdelone.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ilhna <ilhna@student.42seoul.kr>           +#+  +:+       +#+        */
+/*   By: choiejae <choiejae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/07/13 17:19:11 by ilhna             #+#    #+#             */
-/*   Updated: 2022/07/21 09:33:39 by ilhna            ###   ########.fr       */
+/*   Updated: 2023/01/26 13:18:56 by choiejae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,7 +17,6 @@ void	ft_lstdelone(t_list *lst, void (*del)(void *))
 	t_list	*tmpnode;
 
 	tmpnode = lst;
-	lst = lst->next;
 	del(tmpnode->content);
 	free(tmpnode);
 	tmpnode = 0;

--- a/libft/ft_lstnew.c
+++ b/libft/ft_lstnew.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   ft_lstnew.c                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ilhna <ilhna@student.42seoul.kr>           +#+  +:+       +#+        */
+/*   By: choiejae <choiejae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/07/13 14:46:05 by ilhna             #+#    #+#             */
-/*   Updated: 2022/07/21 09:36:56 by ilhna            ###   ########.fr       */
+/*   Updated: 2023/01/25 19:44:31 by choiejae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,5 +21,6 @@ t_list	*ft_lstnew(void *content)
 		return ((void *)0);
 	newnode->content = content;
 	newnode->next = (void *)0;
+	newnode->prev = (void *)0;
 	return (newnode);
 }

--- a/libft/libft.h
+++ b/libft/libft.h
@@ -6,7 +6,7 @@
 /*   By: choiejae <choiejae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/07/06 15:47:08 by ilhna             #+#    #+#             */
-/*   Updated: 2023/01/25 19:43:19 by choiejae         ###   ########.fr       */
+/*   Updated: 2023/01/26 15:11:43 by choiejae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -66,6 +66,7 @@ void	ft_lstadd_front(t_list **lst, t_list *new);
 int		ft_lstsize(t_list *lst);
 t_list	*ft_lstlast(t_list *lst);
 void	ft_lstadd_back(t_list **lst, t_list *new);
+void	ft_d_lstadd_back(t_list **lst, t_list *new);
 void	ft_lstdelone(t_list *lst, void (*del)(void *));
 void	ft_lstclear(t_list **lst, void (*del)(void *));
 void	ft_lstiter(t_list *lst, void (*f)(void *));

--- a/libft/libft.h
+++ b/libft/libft.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   libft.h                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ilhna <ilhna@student.42seoul.kr>           +#+  +:+       +#+        */
+/*   By: choiejae <choiejae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/07/06 15:47:08 by ilhna             #+#    #+#             */
-/*   Updated: 2023/01/24 00:19:49 by ilhna            ###   ########.fr       */
+/*   Updated: 2023/01/25 19:43:19 by choiejae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,6 +20,7 @@ typedef struct s_list
 {
 	void			*content;
 	struct s_list	*next;
+	struct s_list	*prev;
 }					t_list;
 
 int		ft_isalpha(int c);

--- a/srcs_mandatory/load_config.c
+++ b/srcs_mandatory/load_config.c
@@ -6,29 +6,40 @@
 /*   By: choiejae <choiejae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/24 01:47:41 by ilhna             #+#    #+#             */
-/*   Updated: 2023/01/25 19:46:07 by choiejae         ###   ########.fr       */
+/*   Updated: 2023/01/26 13:41:00 by choiejae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "libft.h"
 #include "minishell.h"
 
+#include <stdio.h>
+
 void	load_config(t_config *config, char **envp)
 {
 	int		env_idx;
+	
 	t_list	*cur;
 
-	env_idx = 0;
-	config->env_list = ft_lstnew(new_env(envp[env_idx]));
-	if (config->env_list == NULL)
-		panic("Fail: ft_lstnew()");
-	cur = config->env_list;
+	env_idx = -1;
+	config->head = ft_lstnew(new_env("dummy node=(null)"));
+	if (config->head == NULL)
+		panic("Fail: make head node");
+	config->tail = ft_lstnew(new_env("dummy node=(null)"));
+	if (config->tail == NULL)
+		panic("Fail: make tail node");
+	config->head->next = config->tail;
+	config->tail->prev = config->head;
+	cur = config->head;
 	while (envp[++env_idx])
 	{
 		cur->next = ft_lstnew((void *)new_env(envp[env_idx]));
 		cur->next->prev = cur;
+		config->tail->prev = cur->next;
+		cur->next->next = config->tail;
 		if (cur->next == NULL)
-			panic("Fail: ft_lstnew()");
+			panic("Fail: make next node");
 		cur = cur->next;
 	}
+	cur = config->head;
 }

--- a/srcs_mandatory/load_config.c
+++ b/srcs_mandatory/load_config.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   load_config.c                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ejachoi <ejachoi@student.42.fr>            +#+  +:+       +#+        */
+/*   By: choiejae <choiejae@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/01/24 01:47:41 by ilhna             #+#    #+#             */
-/*   Updated: 2023/01/24 12:56:11 by ejachoi          ###   ########.fr       */
+/*   Updated: 2023/01/25 19:46:07 by choiejae         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,6 +26,7 @@ void	load_config(t_config *config, char **envp)
 	while (envp[++env_idx])
 	{
 		cur->next = ft_lstnew((void *)new_env(envp[env_idx]));
+		cur->next->prev = cur;
 		if (cur->next == NULL)
 			panic("Fail: ft_lstnew()");
 		cur = cur->next;

--- a/srcs_mandatory/main.c
+++ b/srcs_mandatory/main.c
@@ -103,12 +103,8 @@ int	set_env_list(t_list *env_list, char *env_key, char *new_value)
 		cur_env = (t_env *)env_list->content;
 		if (!ft_strncmp(cur_env->key, env_key, ft_strlen(env_key) + 1))
 		{
-			printf("export! 원래 값이 있습니다\n");
-			printf("key ||%s||\n", cur_env->key);
-			printf("origin value ||%s||\n", cur_env->value);
 			if (cur_env->value != NULL)
 				free(cur_env->value);
-			printf("changed value ||%s||\n", new_value);
 			
 			cur_env->value = ft_strdup(new_value);
 			cur_env = NULL;
@@ -184,16 +180,13 @@ int builtin_export(char *buf, t_config *config)
 	char **splited_env;
 
 	list = config->head;
-
 	splited_env_by_pipe = ft_split(buf, '|');
 	splited_env_by_space = ft_split(splited_env_by_pipe[0], ' ');
 	splited_env = ft_split_one_cstm(splited_env_by_space[0], '=');
-
 	if (splited_env == NULL)
 		panic("Fail: splited_env");
 	if (splited_env[1] != NULL && set_env_list(list, splited_env[0], splited_env[1]))
-		ft_lstadd_back(&list, ft_lstnew(new_env(splited_env_by_space[0])));
-
+		ft_d_lstadd_back(&list, ft_lstnew(new_env(splited_env_by_space[0])));
 	free_split(splited_env_by_pipe);
 	free_split(splited_env_by_space);
 	free_split(splited_env);
@@ -205,9 +198,7 @@ void	ft_del(void *content)
 	t_env *env;
 
 	env = (t_env *)content;
-	printf("free key : %s\n", env->key);
 	free(env->key);
-	printf("free value : %s\n", env->value);
 	free(env->value);
 	free(content);
 }
@@ -222,17 +213,12 @@ int builtin_unset(char *const buf, t_config *config)
 	if (splited_env == NULL)
 		panic("Fail: ft_split_one_cstm()");
 	cur = get_env_list(cur, splited_env[0]);
-
 	if (splited_env[1] == NULL && cur)
 	{
 		cur->prev->next = cur->next;
 		cur->next->prev = cur->prev;
-		cur->next = NULL;
-		cur->prev = NULL;
 		ft_lstdelone(cur, ft_del);
 	}
-
-	cur = config->head;
 	free_split(splited_env);
 	return (0);
 }
@@ -269,10 +255,8 @@ int builtin_env(t_config config)
 		list = list->next;
 	}
 	return (0);
-	// error 인 경우가 있을까?
 }
 
-// Execute cmd.  Never returns.
 void runcmd(struct cmd *cmd, t_config config)
 {
 	int status;
@@ -361,23 +345,15 @@ void runcmd(struct cmd *cmd, t_config config)
 	exit(0);
 }
 
-// 1. init_env
 // 2. 히어독 추가
 // 3. 시그널 처리 (ctrl-C, ctrl-D, ctrl-\)
 // 4. 빌트인 함수 만들기
-//		4-1. echo
-//		4-2. cd
-//		4-3. pwd
-//		4-4. export
-//		4-5. unset
-//		4-6. env
 //		4-7. exit
 // 5. exit() 코드($?)
 // 6. add_history();
 // 7. parsing 에서 argc[] 이해
 // 8. $
 // 9. quoting " '
-// 10. 
 
 size_t	get_envp_count(char **system_envp)
 {
@@ -435,9 +411,6 @@ void panic(char *s)
 	printf("%s\n", s);
 	exit(1);
 }
-
-// PAGEBREAK!
-//  Constructors
 
 struct cmd *init_execcmd(void)
 {

--- a/srcs_mandatory/main.c
+++ b/srcs_mandatory/main.c
@@ -89,6 +89,7 @@ t_list	*get_env_list(t_list *env_list, char *env_key)
 		cur_env = (t_env *)env_list->content;
 		if (!ft_strncmp(cur_env->key, env_key, ft_strlen(env_key)))
 			return (env_list);
+			
 		env_list = env_list->next;
 	}
 	return NULL;
@@ -180,11 +181,14 @@ int builtin_export(char *buf, t_config *config)
 	char **splited_env_by_space;
 	char **splited_env;
 
+	printf("||%s||\n", buf);
 	list = config->env_list;
 
 	splited_env_by_pipe = ft_split(buf, '|');
 	splited_env_by_space = ft_split(splited_env_by_pipe[0], ' ');
 	splited_env = ft_split_one_cstm(splited_env_by_space[0], '=');
+
+	printf("||%s||\n", splited_env_by_space[0]);
 	if (splited_env == NULL)
 		panic("Fail: new_env()");
 	if (splited_env[1] != NULL && set_env_list(list, splited_env[0], splited_env[1]))
@@ -209,16 +213,34 @@ void	ft_del(void *content)
 
 int builtin_unset(char *const buf, t_config *config)
 {
-	t_list *list;
+	// t_list	*tmp;
+	t_list	*cur;
 	char **splited_env;
 
-	list = config->env_list;
+	cur = config->env_list;
+
 	splited_env = ft_split_one_cstm(buf, '=');
 	if (splited_env == NULL)
-		panic("Fail: new_env()");
-	list = get_env_list(list, splited_env[0]);
-	if (splited_env[1] == NULL && list)
-		ft_lstdelone(list, ft_del);
+		panic("Fail:  ");
+
+// printf("find\n");
+// printf("|||%s|||\n", splited_env[0]);
+
+	cur = get_env_list(cur, splited_env[0]);
+
+	t_env *env;
+	env = (t_env *)cur->content;
+
+printf("key ||%s||\n", env->key);
+printf("value ||%s||\n", env->value);
+
+	// config->env_list->prev->next = config->env_list->next;
+	// config->env_list->next->prev = config->env_list->prev;
+	
+	
+	if (splited_env[1] == NULL && cur)
+		ft_lstdelone(cur, ft_del);
+		
 	free_split(splited_env);
 	return (0);
 }
@@ -389,30 +411,24 @@ int main(int argc, char **argv, char **envp)
 	while (1)
 	{
 		buf = readline(PROMPT);
-		
-		while (*buf && *buf == ' ')
-			buf++;
-		if (ft_strnstr(buf, "cd ", 3))
+		splited_cmd = ft_split(buf, ' ');
+		if (ft_strnstr(splited_cmd[0], "cd", 2))
 		{
 			if (builtin_cd(buf, &config))
 				printf("cannot cd %s\n", buf+3);
 		}
-		if(ft_strnstr(buf, "export ", 7))
+		if (ft_strnstr(splited_cmd[0], "export", 6))
 		{
-			splited_cmd = ft_split_one_cstm(buf, ' ');
 			if (splited_cmd[2] == NULL && builtin_export(splited_cmd[1], &config))
 				printf("cannot export %s\n", splited_cmd[1]);
-			free_split(splited_cmd);
-    	}
-		if(ft_strnstr(buf, "unset ", 6))
+		}
+		if (ft_strnstr(buf, "unset", 5))
 		{
-			splited_cmd = ft_split_one_cstm(buf, ' ');
 			if (splited_cmd[2] == NULL && builtin_unset(splited_cmd[1], &config))
 				printf("cannot unset %s\n", splited_cmd[1]);
-			free_split(splited_cmd);
-    	}
-		system("leaks minishell");
-
+		}
+		// system("leaks minishell");
+		free_split(splited_cmd);
 		if (fork() == 0)
 			runcmd(parsecmd(buf), config);
 		wait(&status);

--- a/srcs_mandatory/main.c
+++ b/srcs_mandatory/main.c
@@ -78,21 +78,6 @@ char *ft_gets(char *buf, int max)
 	return buf;
 }
 
-int	builtin_echo(char *const argv[])
-{
-	int	idx;
-
-	idx = 0;
-	while (argv[++idx])
-	{
-		if (idx > 1)
-			ft_putchar_fd(' ', STDOUT_FILENO);
-		ft_putstr_fd(argv[idx], STDOUT_FILENO);
-	}
-	ft_putchar_fd('\n', STDOUT_FILENO);
-	return (0);
-}
-
 #include <sys/param.h>
 
 t_list	*get_env_list(t_list *env_list, char *env_key)
@@ -124,6 +109,21 @@ int	set_env_list(t_list *env_list, char *env_key, char *new_value)
 		env_list = env_list->next;
 	}
 	return (1);
+}
+
+int	builtin_echo(char *const argv[])
+{
+	int	idx;
+
+	idx = 0;
+	while (argv[++idx])
+	{
+		if (idx > 1)
+			ft_putchar_fd(' ', STDOUT_FILENO);
+		ft_putstr_fd(argv[idx], STDOUT_FILENO);
+	}
+	ft_putchar_fd('\n', STDOUT_FILENO);
+	return (0);
 }
 
 int builtin_cd(char *const buf, t_config *config)

--- a/srcs_mandatory/main.c
+++ b/srcs_mandatory/main.c
@@ -314,16 +314,6 @@ size_t	get_envp_count(char **system_envp)
 	return (len);
 }
 
-// t_env_node	*new_environ(char **system_envp)
-// {
-// 	size_t	env_count;
-// 	t_env_node *new_envp;
-
-// 	env_count = get_envp_count(system_envp);
-// 	new_envp = new_node;
-// 	return (new_envp);
-// }
-
 int main(int argc, char **argv, char **envp)
 {
 	char	*buf;


### PR DESCRIPTION
[dea6a3a](https://github.com/ejaee/42Minishell/pull/34/commits/dea6a3aa19c8b69f772408ea3c418eb850504867)
- export에서 기존의 값이 변경되지 않는 에러 발견

- [해결안] 기존의 값이 있는 경우 기존의 값 공간을 free 하고 ft_strdup를 통해 새로 할당 + value

[67b0a65](https://github.com/ejaee/42Minishell/pull/34/commits/67b0a654f68f768e4dfb1c00d7c9ea9e48d758d1)
- unset의 원활함을 위해 이중 연결리스트 + 원활한 연결을 위해 앞, 뒤에 dummy node 생성
- 구조체 변수 env_list 를 head와 tail로 나누어 관리
- 기존에 env_list는 모두 head로 이름이 변경되어야 합니다(혹시 안된 부분이 있다면 말씀해주세요!)
- head와 tail은 각각 더미노드를 가리키므로 첫번째 또는 마지막 노드에 접근하기 위해서는 각 한칸씩 이동해야 합니다
- cur = head->next | cur =tail->prev

[추가적인 개선사항]
- input 값으로 맨 앞에 많은 공백이 왔을 때 trim 처리
- ex) "                export e=2 " -> export e=2 실행
- ex) "                export e=2 | pwd " pwd 만 실행
- ex) "                pwd | export e=2 " 아무것도 실행 x

- unset에서 _을 삭제하려 했는데 그보다 앞에 __가 있어 제대로 get 하지 못한 문제
- [해결안] _'\0'까지 확인하도록 수정

